### PR TITLE
Fix links to point to doc.atomvm.org

### DIFF
--- a/markdown/ssd1306.md
+++ b/markdown/ssd1306.md
@@ -15,9 +15,9 @@ For more information about the ESP32 I2C interface, see the [ESP IDF SDK I2C doc
 
 The AtomVM SSD1306 driver is implemented as an AtomVM component, which includes some native C code that must be linked into the ESP32 AtomVM image.  In order to build and deploy this client code, you must build an AtomVM binary image.
 
-For general instructions about how to build AtomVM and include third-party components into an AtomVM image, see the [AtomVM Build Instructions](https://doc.atomvm.net/build-instructions.html).
+For general instructions about how to build AtomVM and include third-party components into an AtomVM image, see the [AtomVM Build Instructions](https://doc.atomvm.org/latest/build-instructions.html).
 
-Once the AtomVM image including this component has been built, you can flash the image to your ESP32 device.  For instructions about how to flash AtomVM images to your ESP32 device, see the AtomVM [Getting Started Guide](https://doc.atomvm.net/getting-started-guide.html).
+Once the AtomVM image including this component has been built, you can flash the image to your ESP32 device.  For instructions about how to flash AtomVM images to your ESP32 device, see the AtomVM [Getting Started Guide](https://doc.atomvm.org/latest/getting-started-guide.html).
 
 Once the AtomVM image including this component has been flashed to your ESP32 device, you can then include this project into your [`rebar3`](https://www.rebar3.org) project using the [`atomvm_rebar3_plugin`](https://github.com/atomvm/atomvm_rebar3_plugin), which provides targets for building AtomVM packbeam files and flashing them to your device.
 


### PR DESCRIPTION
Fixes already broken links by pointing them to the new doc.atomvm.org domain. Previously these were directed to the incorrect doc.atomvm.net domain.